### PR TITLE
Update MySQL volume path

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ docker-compose up
 ```
 
 The Streamlit interface will be available on
-`http://localhost:8501` and MySQL will listen on port `3306`.  Kafka
-components are exposed on ports `9092`, `9093`, `8080` and `8082` as configured
+`http://localhost:8501` and MySQL will listen on port `3306`.
+Persistent MySQL data is stored in the `./MySql_Volume` directory by default.
+Kafka components are exposed on ports `9092`, `9093`, `8080` and `8082` as configured
 in `docker-compose.yml`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     ports:
       - "3306:3306"  # Expose MySQL on localhost:3306
     volumes:
-      - /Users/spatkar/PycharmProjects/Health_Tracker_Python/MySql_Volume:/var/lib/mysql
+      - ./MySql_Volume:/var/lib/mysql
 #volumes:
 #  mysql-data:
 


### PR DESCRIPTION
## Summary
- use relative MySQL volume path in `docker-compose.yml`
- document default MySQL data directory in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d891fe970832596dedf322cd9d39a